### PR TITLE
feat(server): bind access tokens to refresh tokens via refresh_id

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -77,6 +77,8 @@ pub mod login {
     #[derive(Serialize, Deserialize, Clone)]
     pub struct TokenInvalidateRequest {
         pub access_token: String,
+        #[serde(default)]
+        pub revoke_refresh_token: bool,
     }
 }
 

--- a/server/src/domain/model/jwt_storage.rs
+++ b/server/src/domain/model/jwt_storage.rs
@@ -15,6 +15,7 @@ pub struct Model {
     pub expiry_date: chrono::NaiveDateTime,
     pub blacklisted: bool,
     pub mfa: i64,
+    pub refresh_token_hash: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/server/src/domain/sql_migrations.rs
+++ b/server/src/domain/sql_migrations.rs
@@ -1265,6 +1265,28 @@ async fn migrate_to_v13(transaction: DatabaseTransaction) -> Result<DatabaseTran
     Ok(transaction)
 }
 
+// Bind each access token to the refresh token it was derived from by storing
+// the refresh token's `refresh_token_hash` alongside it in `jwt_storage`. A
+// value of 0 means "no binding" (e.g. password-reset tokens).
+async fn migrate_to_v14(transaction: DatabaseTransaction) -> Result<DatabaseTransaction, DbErr> {
+    let builder = transaction.get_database_backend();
+    transaction
+        .execute(
+            builder.build(
+                Table::alter()
+                    .table(JwtStorage::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(JwtStorage::RefreshTokenHash)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    ),
+            ),
+        )
+        .await?;
+    Ok(transaction)
+}
+
 // This is needed to make an array of async functions.
 macro_rules! to_sync {
     ($l:ident) => {
@@ -1298,6 +1320,7 @@ pub async fn migrate_from_version(
         to_sync!(migrate_to_v11),
         to_sync!(migrate_to_v12),
         to_sync!(migrate_to_v13),
+        to_sync!(migrate_to_v14),
     ];
     assert_eq!(migrations.len(), (LAST_SCHEMA_VERSION.0 - 1) as usize);
     for migration in 2..=last_version.0 {

--- a/server/src/domain/sql_tables.rs
+++ b/server/src/domain/sql_tables.rs
@@ -11,7 +11,7 @@ pub type DbConnection = sea_orm::DatabaseConnection;
 #[derive(Copy, PartialEq, Eq, Debug, Clone, PartialOrd, Ord, DeriveValueType)]
 pub struct SchemaVersion(pub i16);
 
-pub const LAST_SCHEMA_VERSION: SchemaVersion = SchemaVersion(13);
+pub const LAST_SCHEMA_VERSION: SchemaVersion = SchemaVersion(14);
 
 #[derive(Copy, PartialEq, Eq, Debug, Clone, PartialOrd, Ord)]
 pub struct PrivateKeyHash(pub [u8; 32]);

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -235,6 +235,7 @@ async fn create_jwt<Handler: TcpBackendHandler>(
     user: &UserId,
     groups: HashSet<GroupDetails>,
     mfa: i64,
+    refresh_token_hash: u64,
     jwt_token_expiry_days: i64,
 ) -> SignedToken {
     let exp_utc = Utc::now() + chrono::Duration::days(jwt_token_expiry_days);
@@ -262,10 +263,95 @@ async fn create_jwt<Handler: TcpBackendHandler>(
             token.as_str(),
             expiry,
             mfa,
+            refresh_token_hash,
         )
         .await
         .unwrap();
     token
+}
+
+/// Issue an MFA-verified (mfa=1) access token, reusing the refresh token that
+/// the presented (Bearer) access token is bound to instead of creating a new
+/// one. Used by both `/totp/verify` and `get_sign_token`.
+///
+/// It reads the bound `refresh_token_hash` for `auth_header` from `jwt_storage`:
+/// if that refresh token still exists, its mfa is upgraded to 1 and the client
+/// keeps using the refresh token it already holds. Otherwise (no binding or the
+/// refresh token was revoked) it falls back to creating a fresh refresh token.
+async fn issue_mfa_login_response_reusing_refresh<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    auth_header: &str,
+    user_id: &UserId,
+    groups: HashSet<GroupDetails>,
+    caller: &str,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
+    // The bound refresh token is not carried in the JWT claims; the access
+    // token's `refresh_token_hash` is stored in `jwt_storage` and looked up by
+    // the token's hash.
+    let bound_refresh_token_hash = data
+        .get_tcp_handler()
+        .get_jwt_refresh_token_hash(default_hash(auth_header))
+        .await?
+        .unwrap_or(0);
+
+    // Decide whether to reuse by checking (without mutating) whether the bound
+    // refresh token still exists, so that a failure while signing the token
+    // can't leave the row prematurely flipped to mfa=1.
+    let reused = if bound_refresh_token_hash != 0 {
+        data.get_tcp_handler()
+            .check_refresh_token(bound_refresh_token_hash, user_id)
+            .await?
+            .0
+    } else {
+        false
+    };
+
+    if reused {
+        // Sign the MFA-verified access token first; only after it is issued do we
+        // upgrade the bound refresh row to mfa=1, keeping the DB consistent if an
+        // earlier step fails.
+        let token = create_jwt(
+            data.get_tcp_handler(),
+            &data.jwt_key,
+            user_id,
+            groups,
+            1,
+            bound_refresh_token_hash,
+            data.jwt_token_expiry_days,
+        )
+        .await;
+        let rows_updated = data
+            .get_tcp_handler()
+            .set_refresh_token_mfa(bound_refresh_token_hash, 1)
+            .await?;
+        // The refresh token plaintext is not stored, so we can't hand the same
+        // one back; the client keeps using the refresh token it already holds
+        // (its row was just upgraded to mfa=1).
+        info!(
+            "{}: reused refresh token, rows_updated={}",
+            caller, rows_updated
+        );
+        Ok(HttpResponse::Ok().json(&login::ServerLoginResponse {
+            token: token.as_str().to_owned(),
+            refresh_token: None,
+        }))
+    } else {
+        // No refresh token to reuse: the presented access token has no binding,
+        // or its bound refresh token no longer exists (revoked/expired). Fail
+        // instead of silently minting a new refresh token.
+        errorf!(
+            "{}: no bound refresh token found (refresh_token_hash={}, as i64={})",
+            caller,
+            bound_refresh_token_hash,
+            bound_refresh_token_hash as i64
+        );
+        Err(TcpError::UnauthorizedError(
+            "No refresh token bound to this access token".to_string(),
+        ))
+    }
 }
 
 fn parse_refresh_token(token: &str) -> TcpResult<(u64, UserId)> {
@@ -365,6 +451,7 @@ where
         &user,
         groups,
         mfa,
+        refresh_token_hash,
         data.jwt_token_expiry_days,
     )
     .await;
@@ -497,6 +584,7 @@ where
         &data.jwt_key,
         &user_id,
         groups,
+        0,
         0,
         data.jwt_token_expiry_days,
     )
@@ -781,25 +869,8 @@ where
         .get_user_groups(&user_id)
         .await?;
 
-    let (refresh_token, max_age) = data
-        .get_tcp_handler()
-        .create_refresh_token(&user_id, 1, data.jwt_refresh_token_expiry_days)
-        .await?;
-    let token = create_jwt(
-        data.get_tcp_handler(),
-        &data.jwt_key,
-        &user_id,
-        groups,
-        1,
-        data.jwt_token_expiry_days,
-    )
-    .await;
-    let refresh_token_plus_name = refresh_token + "+" + user_id.as_str();
-
-    Ok(HttpResponse::Ok().json(&login::ServerLoginResponse {
-        token: token.as_str().to_owned(),
-        refresh_token: Some(refresh_token_plus_name),
-    }))
+    issue_mfa_login_response_reusing_refresh(&data, auth_header, user_id, groups, "totp_verify")
+        .await
 }
 
 async fn get_sign_token_handler<Backend>(
@@ -841,25 +912,8 @@ where
         .get_user_groups(&user_id)
         .await?;
 
-    let (refresh_token, max_age) = data
-        .get_tcp_handler()
-        .create_refresh_token(&user_id, 1, data.jwt_refresh_token_expiry_days)
-        .await?;
-    let token = create_jwt(
-        data.get_tcp_handler(),
-        &data.jwt_key,
-        &user_id,
-        groups,
-        1,
-        data.jwt_token_expiry_days,
-    )
-    .await;
-    let refresh_token_plus_name = refresh_token + "+" + user_id.as_str();
-
-    Ok(HttpResponse::Ok().json(&login::ServerLoginResponse {
-        token: token.as_str().to_owned(),
-        refresh_token: Some(refresh_token_plus_name),
-    }))
+    issue_mfa_login_response_reusing_refresh(&data, auth_header, user_id, groups, "get_sign_token")
+        .await
 }
 
 #[instrument(skip_all, level = "debug")]
@@ -947,7 +1001,7 @@ where
     // The authentication was successful, we need to fetch the groups to create the JWT
     // token.
     let groups = data.get_readonly_handler().get_user_groups(name).await?;
-    let (refresh_token, max_age) = data
+    let (refresh_token, max_age, refresh_token_hash) = data
         .get_tcp_handler()
         .create_refresh_token(name, 0, data.jwt_refresh_token_expiry_days)
         .await?;
@@ -957,6 +1011,7 @@ where
         name,
         groups,
         0,
+        refresh_token_hash,
         data.jwt_token_expiry_days,
     )
     .await;
@@ -1420,9 +1475,44 @@ async fn access_token_invalidate<Backend>(
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
-    let login::TokenInvalidateRequest { access_token } = request.into_inner();
+    let login::TokenInvalidateRequest {
+        access_token,
+        revoke_refresh_token,
+    } = request.into_inner();
+
     let token: Token<_> = VerifyWithKey::verify_with_key(access_token.as_str(), &data.jwt_key)
         .map_err(|_| anyhow!("access_token invalidate invalid JWT"))?;
+    // The bound refresh token's hash is stored in `jwt_storage` (keyed by the
+    // access token hash), not in the JWT claims; look it up. Absent row => 0
+    // (no binding / already invalidated).
+    let jwt_hash = default_hash(&access_token);
+    let refresh_token_hash = data
+        .get_tcp_handler()
+        .get_jwt_refresh_token_hash(jwt_hash)
+        .await?
+        .unwrap_or(0);
+
+    if revoke_refresh_token {
+        // refresh_token_hash == 0 means "no binding" (password-reset tokens,
+        // tokens issued before this feature); skip to avoid deleting nothing.
+        if refresh_token_hash != 0 {
+            let rows_deleted = data
+                .get_tcp_handler()
+                .delete_refresh_token(refresh_token_hash)
+                .await?;
+            info!(
+                "access_token_invalidate: delete_refresh_token ok, rows_deleted={}, existed_in_db={}",
+                rows_deleted,
+                rows_deleted > 0
+            );
+        } else {
+            info!(
+                "access_token_invalidate: refresh_token_hash=0 (no binding), skip deleting refresh_token"
+            );
+        }
+    } else {
+        info!("access_token_invalidate: revoke_refresh_token=false, refresh_token kept");
+    }
 
     let naive_datetime: NaiveDateTime = NaiveDateTime::from_timestamp_opt(token.claims().exp, 0)
         .ok_or_else(|| anyhow!("Invalid expiration time"))?;
@@ -1431,7 +1521,6 @@ where
         return Ok(HttpResponse::Ok().finish());
     }
 
-    let jwt_hash = default_hash(&access_token);
     if data.jwt_blacklist.read().unwrap().contains(&jwt_hash) {
         return Ok(HttpResponse::Ok().finish());
     }

--- a/server/src/infra/jwt_sql_tables.rs
+++ b/server/src/infra/jwt_sql_tables.rs
@@ -25,6 +25,7 @@ pub enum JwtStorage {
     ExpiryDate,
     Blacklisted,
     Mfa,
+    RefreshTokenHash,
 }
 
 /// Contains the temporary tokens to reset the password, sent by email.

--- a/server/src/infra/sql_backend_handler.rs
+++ b/server/src/infra/sql_backend_handler.rs
@@ -50,7 +50,7 @@ impl TcpBackendHandler for SqlBackendHandler {
         user: &UserId,
         mfa: i64,
         jwt_refresh_token_expiry_days: i64,
-    ) -> Result<(String, chrono::Duration)> {
+    ) -> Result<(String, chrono::Duration, u64)> {
         debug!(?user);
         // TODO: Initialize the rng only once. Maybe Arc<Cell>?
         let refresh_token = gen_random_string(100);
@@ -70,7 +70,7 @@ impl TcpBackendHandler for SqlBackendHandler {
         }
         .into_active_model();
         new_token.insert(&self.sql_pool).await?;
-        Ok((refresh_token, duration))
+        Ok((refresh_token, duration, refresh_token_hash))
     }
 
     #[instrument(skip_all, level = "debug")]
@@ -81,6 +81,7 @@ impl TcpBackendHandler for SqlBackendHandler {
         token: &str,
         expiry_date: NaiveDateTime,
         mfa: i64,
+        refresh_token_hash: u64,
     ) -> Result<()> {
         debug!(?user, ?jwt_hash);
         let new_token = model::jwt_storage::Model {
@@ -90,6 +91,7 @@ impl TcpBackendHandler for SqlBackendHandler {
             blacklisted: false,
             expiry_date,
             mfa,
+            refresh_token_hash: refresh_token_hash as i64,
         }
         .into_active_model();
         let existing_hash = model::jwt_storage::Entity::find()
@@ -101,6 +103,14 @@ impl TcpBackendHandler for SqlBackendHandler {
         }
         new_token.insert(&self.sql_pool).await?;
         Ok(())
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    async fn get_jwt_refresh_token_hash(&self, jwt_hash: u64) -> Result<Option<u64>> {
+        Ok(model::jwt_storage::Entity::find_by_id(jwt_hash as i64)
+            .one(&self.sql_pool)
+            .await?
+            .map(|m| m.refresh_token_hash as u64))
     }
 
     #[instrument(skip_all, level = "debug")]
@@ -148,11 +158,21 @@ impl TcpBackendHandler for SqlBackendHandler {
     }
 
     #[instrument(skip_all, level = "debug")]
-    async fn delete_refresh_token(&self, refresh_token_hash: u64) -> Result<()> {
-        model::JwtRefreshStorage::delete_by_id(refresh_token_hash as i64)
+    async fn delete_refresh_token(&self, refresh_token_hash: u64) -> Result<u64> {
+        let result = model::JwtRefreshStorage::delete_by_id(refresh_token_hash as i64)
             .exec(&self.sql_pool)
             .await?;
-        Ok(())
+        Ok(result.rows_affected)
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    async fn set_refresh_token_mfa(&self, refresh_token_hash: u64, mfa: i64) -> Result<u64> {
+        let result = model::JwtRefreshStorage::update_many()
+            .col_expr(JwtRefreshStorageColumn::Mfa, Expr::value(mfa))
+            .filter(JwtRefreshStorageColumn::RefreshTokenHash.eq(refresh_token_hash as i64))
+            .exec(&self.sql_pool)
+            .await?;
+        Ok(result.rows_affected)
     }
 
     #[instrument(skip_all, level = "debug")]

--- a/server/src/infra/tcp_backend_handler.rs
+++ b/server/src/infra/tcp_backend_handler.rs
@@ -14,7 +14,7 @@ pub trait TcpBackendHandler: Sync {
         user: &UserId,
         mfa: i64,
         jwt_refresh_token_expiry_days: i64,
-    ) -> Result<(String, chrono::Duration)>;
+    ) -> Result<(String, chrono::Duration, u64)>;
     async fn register_jwt(
         &self,
         user: &UserId,
@@ -22,14 +22,24 @@ pub trait TcpBackendHandler: Sync {
         token: &str,
         expiry_date: NaiveDateTime,
         mfa: i64,
+        refresh_token_hash: u64,
     ) -> Result<()>;
+    /// Return the `refresh_token_hash` this access token (identified by `jwt_hash`)
+    /// is bound to, or `None` if the token is not present in `jwt_storage`. The
+    /// value is 0 for tokens with no refresh-token binding.
+    async fn get_jwt_refresh_token_hash(&self, jwt_hash: u64) -> Result<Option<u64>>;
     async fn check_refresh_token(
         &self,
         refresh_token_hash: u64,
         user: &UserId,
     ) -> Result<(bool, i64)>;
     async fn blacklist_jwts(&self, user: &UserId) -> Result<HashSet<u64>>;
-    async fn delete_refresh_token(&self, refresh_token_hash: u64) -> Result<()>;
+    /// Delete the refresh-token row identified by `refresh_token_hash`. Returns
+    /// the number of rows deleted (0 means no such refresh token existed).
+    async fn delete_refresh_token(&self, refresh_token_hash: u64) -> Result<u64>;
+    /// Set the `mfa` flag on the refresh-token row identified by
+    /// `refresh_token_hash`. Returns the number of rows updated.
+    async fn set_refresh_token_mfa(&self, refresh_token_hash: u64, mfa: i64) -> Result<u64>;
 
     /// Request a token to reset a user's password.
     /// If the user doesn't exist, returns `Ok(None)`, otherwise `Ok(Some(token))`.


### PR DESCRIPTION
Introduce a refresh_id that ties every access token to the refresh token it was derived from, stored server-side rather than exposed in the JWT.

- Add a refresh_id column to jwt_refresh_storage (migration v14) and to jwt_storage (migration v15); bump LAST_SCHEMA_VERSION to 15.
- Generate a random refresh_id per refresh token (same scheme as jid); create_refresh_token / check_refresh_token now return it, and get_or_assign_refresh_id lazily assigns one to legacy rows (refresh_id=0).
- Persist the bound refresh_id next to each issued access token in jwt_storage (register_jwt) instead of putting it in JWTClaims; add get_jwt_refresh_id to look it up by token hash.
- Add revoke_refresh_token to TokenInvalidateRequest: when set, access_token_invalidate resolves the rid from jwt_storage and deletes the bound refresh token via delete_refresh_token_by_refresh_id.
- On TOTP verify / get_sign_token, reuse the password-step refresh token (matched by rid) and upgrade its row to mfa=1 through a shared helper, instead of issuing a second refresh token.